### PR TITLE
v1.0.2 update 🦜

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.0.2
+
+*   **Feature:** Added optional `showOpacity` parameter to `ColorPicker` (defaults to `true`). Allows hiding the opacity slider and expands the color display.
+*   **Docs:** Updated `README.md` example to demonstrate the new `showOpacity` feature.
+*   **Doc Fix** Updated the `pubspec.yaml` to confine to Dart file convention description restrictions.
+*   **Fix:** Updated `Color` extension methods (`toHex`, `toHexAlpha`) to use the non-deprecated `r`, `g`, `b`, `a` properties instead of `red`, `green`, `blue`, `alpha`.
+
 ## 1.0.1
 
 *   **Docs** Updated the documentation with images and improved missing descriptions. 🦜

--- a/README.md
+++ b/README.md
@@ -2,20 +2,19 @@
 
 [![pub package](https://img.shields.io/pub/v/compact_color_picker.svg)](https://pub.dev/packages/compact_color_picker)
 
-A simple & clean color picker widget for Flutter. Designed to be compact (mobile-first) yet powerful, suitable for all platforms! It provides a user-friendly interface for selecting colors via Hue, Saturation, Lightness, and Opacity controls.
-
-Inspired by modern color selection tools, it aims to fit seamlessly into various UI layouts without taking up excessive space.
+A simple & clean color picker widget with opacity for Flutter. Designed to be powerful yet compact (mobile-first), suitable for all platforms! Providing a compact user-friendly interface for selecting colors via Hue, Saturation, Lightness, and Opacity controls.
 
 **Features:**
 
-*   Compact design ideal for mobile and desktop layouts.
+*   Compact design will never overflow, ideal for mobile or desktop layouts. 
 *   Hue, Saturation, Lightness, and Opacity sliders.
-*   Interactive preview bubble shows the color directly under the user's touch point during selection.
-*   Optional Hex code display.
+*   Interactive preview bubble ensures users can see the color when tapping during selection.
+*   Optional Opacity Selector.
+*   Optional built-in Hex code display.
 *   Provides selected color via a standard `Color` object callback.
 *   Includes utility extensions for easy conversion to Hex strings (`#RRGGBB`, `#AARRGGBB`).
 *   Customizable initial color.
-*   Rounded corner styling options.
+*   Simple styling that fits in any application.
 
 <img src="https://raw.githubusercontent.com/brayflex/compact_color_picker/main/assets/compact_color_picker.gif" alt="Compact Color Picker in Action">
 
@@ -26,7 +25,7 @@ Inspired by modern color selection tools, it aims to fit seamlessly into various
 
     ```yaml
     dependencies:
-      compact_color_picker: ^[latest_version] # Replace with the latest version
+      compact_color_picker: ^1.0.2 
     ```
 
 2.  **Install:**
@@ -84,6 +83,7 @@ class _MyColorSelectorState extends State<MyColorSelector> {
             initialColor: _currentColor,
             onColorChanged: _handleColorChanged,
             showHexCode: true, // Optionally display the hex code
+            showOpacity: false, // Optionally hide the opacity slider
           ),
         ),
         const SizedBox(height: 16),
@@ -132,8 +132,6 @@ void _handleColorChanged(Color color) {
   print('HSV: (${hsv.hue.toStringAsFixed(1)}, ${hsv.saturation.toStringAsFixed(2)}, ${hsv.value.toStringAsFixed(2)})');
 }
 ```
-
-You can also easily convert between `Color`, `HSVColor`, and `HSLColor` using Flutter's built-in methods: (This part seems redundant now, removing)
 
 ## 💖 Credit
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -68,6 +68,8 @@ class _ExamplePageState extends State<ExamplePage> {
               height: 375, // Example height (maintaining ~4:5 ratio)
               child: ColorPicker(
                 initialColor: _selectedColor,
+                showHexCode: false,
+                showOpacity: true,
                 onColorChanged: _handleColorChanged, // Use the new callback
               ),
             ),

--- a/lib/example.dart
+++ b/lib/example.dart
@@ -1,4 +1,5 @@
 import 'package:compact_color_picker/compact_color_picker.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 void main() {
@@ -9,6 +10,11 @@ class ExampleApp extends StatelessWidget {
   const ExampleApp({super.key});
   final String _title = 'Compact Color Picker Demo';
 
+    // Callback handler for the ColorPicker
+  void _handleColorChanged(Color color) {
+    if(kDebugMode) print(color.toString()); // Print the selected color
+  }
+
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
@@ -18,7 +24,12 @@ class ExampleApp extends StatelessWidget {
         appBar: AppBar(
           title: Text(_title),
         ),
-        body: const ColorPicker(initialColor: Colors.blueGrey),
+        body: ColorPicker(
+          initialColor: Colors.blueGrey,
+          showHexCode: false,
+          showOpacity: true,
+          onColorChanged: _handleColorChanged, // Use the new callback
+          ),
       ),
     );
   }

--- a/lib/src/color_picker.dart
+++ b/lib/src/color_picker.dart
@@ -1,5 +1,4 @@
 import 'package:compact_color_picker/compact_color_picker.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import 'hue_slider.dart';
@@ -19,13 +18,14 @@ class ColorPicker extends StatefulWidget {
     Key? key,
     this.initialColor = _defaultInitialColor, // Make optional and provide default
     this.onColorChanged,
-    this.showHexCode = false
+    this.showHexCode = false,
+    this.showOpacity = true, // Add showOpacity field
   }) : super(key: key);
 
   final Color initialColor;
   final ColorChangedCallback? onColorChanged;
-
   final bool showHexCode;
+  final bool showOpacity; // Declare showOpacity field
 
   @override
   State<ColorPicker> createState() => _ColorPicker();
@@ -34,12 +34,14 @@ class ColorPicker extends StatefulWidget {
 class _ColorPicker extends State<ColorPicker> {
   late HSVColor _hsvColor;
   late bool _showHexCode;
+  late bool _showOpacity; // Add state variable for showOpacity
 
   @override
   void initState() {
     super.initState();
     _hsvColor = HSVColor.fromColor(widget.initialColor);
     _showHexCode = widget.showHexCode;
+    _showOpacity = widget.showOpacity; // Initialize state variable
   }
 
   @override
@@ -47,10 +49,17 @@ class _ColorPicker extends State<ColorPicker> {
     return Column(children: [
       _buildHueSlider(),
       Expanded(child: _buildLightnessAndSaturationPicker()),
-      Row(children: [
-        Expanded(child: _buildOpacitySlider()),
-        _buildColorDisplay(),
-      ],),
+      // Conditionally build the bottom row based on showOpacity
+      if (_showOpacity)
+        Row(children: [
+          Expanded(child: _buildOpacitySlider()),
+          _buildColorDisplay(),
+        ])
+      else
+        // If opacity is hidden, show only the color display, expanded
+        Row(children: [
+          Expanded(child: _buildColorDisplay()),
+        ]),
     ]);
   }
 
@@ -101,12 +110,20 @@ class _ColorPicker extends State<ColorPicker> {
 
 
   Widget _buildColorDisplay() {
-    return Container(height: 40, width: 150, 
-    // color: _hsvColor.toColor(),
-    decoration: BoxDecoration(
-      color: _hsvColor.toColor(), 
-      borderRadius: const BorderRadius.only(bottomRight: Radius.circular(5))
-      ),
+    // Adjust width and border radius based on whether opacity slider is shown
+    final double displayWidth = _showOpacity ? 150 : double.infinity;
+    final BorderRadius borderRadius = _showOpacity
+        ? const BorderRadius.only(bottomRight: Radius.circular(5))
+        : const BorderRadius.only(
+            bottomRight: Radius.circular(5), bottomLeft: Radius.circular(5));
+
+    return Container(
+        height: 40,
+        width: displayWidth,
+        decoration: BoxDecoration(
+          color: _hsvColor.toColor(),
+          borderRadius: borderRadius, // Use dynamic border radius
+        ),
         child: Center(
           child: Padding(
               padding: const EdgeInsets.symmetric(horizontal: 7),

--- a/lib/src/color_utils.dart
+++ b/lib/src/color_utils.dart
@@ -6,11 +6,11 @@ extension CompactColorPickerColorUtils on Color {
   ///
   /// Example: `Colors.red.toHex()` returns `'FF0000'`.
   String toHex() {
-    // Construct hex string from R, G, B components using .red, .green, .blue
-    final String r = red.toRadixString(16).padLeft(2, '0');
-    final String g = green.toRadixString(16).padLeft(2, '0');
-    final String b = blue.toRadixString(16).padLeft(2, '0');
-    return '$r$g$b'.toUpperCase();
+    // Construct hex string from R, G, B components using .r, .g, .b
+    final String rStr = (r * 255).toInt().toRadixString(16).padLeft(2, '0');
+    final String gStr = (g * 255).toInt().toRadixString(16).padLeft(2, '0');
+    final String bStr = (b * 255).toInt().toRadixString(16).padLeft(2, '0');
+    return '$rStr$gStr$bStr'.toUpperCase();
   }
 
   /// Converts the color to a Hex string in the format #RRGGBB.
@@ -24,12 +24,12 @@ extension CompactColorPickerColorUtils on Color {
   ///
   /// Example: `Colors.red.withOpacity(0.5).toHexAlpha()` returns `'80FF0000'`.
   String toHexAlpha() {
-    // Construct hex string from A, R, G, B components using .alpha, .red, .green, .blue
-    final String a = alpha.toRadixString(16).padLeft(2, '0');
-    final String r = red.toRadixString(16).padLeft(2, '0');
-    final String g = green.toRadixString(16).padLeft(2, '0');
-    final String b = blue.toRadixString(16).padLeft(2, '0');
-    return '$a$r$g$b'.toUpperCase();
+    // Construct hex string from A, R, G, B components using .a, .r, .g, .b
+    final String aStr = (a * 255).toInt().toRadixString(16).padLeft(2, '0');
+    final String rStr = (r * 255).toInt().toRadixString(16).padLeft(2, '0');
+    final String gStr = (g * 255).toInt().toRadixString(16).padLeft(2, '0');
+    final String bStr = (b * 255).toInt().toRadixString(16).padLeft(2, '0');
+    return '$aStr$rStr$gStr$bStr'.toUpperCase();
   }
 
   /// Converts the color to a Hex string including alpha, in the format #AARRGGBB.

--- a/lib/src/hue_slider.dart
+++ b/lib/src/hue_slider.dart
@@ -71,10 +71,8 @@ class _HueSliderState extends State<HueSlider> {
       builder: (context) => _buildPreviewBubbleWidget(),
     );
     // Explicit null check for OverlayState
-    final OverlayState? overlayState = Overlay.of(context);
-    if (overlayState != null) {
+    final OverlayState overlayState = Overlay.of(context);
       overlayState.insert(_previewBubbleOverlay!);
-    }
   }
 
   void _updatePreviewBubble() {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: compact_color_picker
-description: A simple & clean color picker widget for Flutter. Designed to be compact (mobile-first) yet powerful, suitable for all platforms! It provides a user-friendly interface for selecting colors via Hue, Saturation, Lightness, and Opacity controls.
-version: 1.0.1 # Updated version
+description: 🦜 A simple & clean color picker widget with opacity for Flutter. Designed to be powerful yet compact (mobile-first), suitable for all platforms!
+version: 1.0.2 # Updated version
 homepage: https://github.com/BrayFlex/compact_color_picker # Assuming this is the repo URL
 repository: https://github.com/BrayFlex/compact_color_picker # Add repository URL
 
@@ -16,40 +16,3 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^2.0.2
-
-# For information on the generic Dart part of this file, see the
-# following page: https://dart.dev/tools/pub/pubspec
-
-# The following section is specific to Flutter packages.
-flutter:
-
-  # To add assets to your package, add an assets section, like this:
-  # assets:
-  #   - images/a_dot_burr.jpeg
-  #   - images/a_dot_ham.jpeg
-  #
-  # For details regarding assets in packages, see
-  # https://flutter.dev/assets-and-images/#from-packages
-  #
-  # An image asset can refer to one or more resolution-specific "variants", see
-  # https://flutter.dev/assets-and-images/#resolution-aware
-
-  # To add custom fonts to your package, add a fonts section here,
-  # in this "flutter" section. Each entry in this list should have a
-  # "family" key with the font family name, and a "fonts" key with a
-  # list giving the asset and other descriptors for the font. For
-  # example:
-  # fonts:
-  #   - family: Schyler
-  #     fonts:
-  #       - asset: fonts/Schyler-Regular.ttf
-  #       - asset: fonts/Schyler-Italic.ttf
-  #         style: italic
-  #   - family: Trajan Pro
-  #     fonts:
-  #       - asset: fonts/TrajanPro.ttf
-  #       - asset: fonts/TrajanPro_Bold.ttf
-  #         weight: 700
-  #
-  # For details regarding fonts in packages, see
-  # https://flutter.dev/custom-fonts/#from-packages

--- a/test/basic_color_picker_test.dart
+++ b/test/basic_color_picker_test.dart
@@ -1,4 +1,5 @@
 import 'package:compact_color_picker/compact_color_picker.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -25,7 +26,7 @@ void main() {
         ),
       ),
     );
-
+    if (kDebugMode) print(selectedColor.toString());
     // Verify the picker is displayed
     expect(find.byType(ColorPicker), findsOneWidget);
 


### PR DESCRIPTION
## 1.0.2 - Changelog

*   **Feature:** Added optional `showOpacity` parameter to `ColorPicker` (defaults to `true`). Allows hiding the opacity slider and expands the color display.
*   **Docs:** Updated `README.md` example to demonstrate the new `showOpacity` feature.
*   **Doc Fix** Updated the `pubspec.yaml` to confine to Dart file convention description restrictions.
*   **Fix:** Updated `Color` extension methods (`toHex`, `toHexAlpha`) to use the non-deprecated `r`, `g`, `b`, `a` properties instead of `red`, `green`, `blue`, `alpha`.